### PR TITLE
Updating the way attribution source URLs are rendered

### DIFF
--- a/candela-citation.php
+++ b/candela-citation.php
@@ -3,7 +3,7 @@
  * @wordpress-plugin
  * Plugin Name:       Candela Citation
  * Description:       Creative Commons Attributions for Candela/Pressbooks
- * Version:           0.2.2
+ * Version:           0.2.3
  * Author:            Lumen Learning
  * Author URI:        http://lumenlearning.com
  * Text Domain:       lti

--- a/inc/class-citation.php
+++ b/inc/class-citation.php
@@ -173,12 +173,8 @@ class Citation {
 								$parts[] = $info['prefix'] . esc_html( $license[ $citation[ $field ] ]['label'] ) . $info['suffix'];
 							}
 							break;
-						case 'url':
-							if ( ! empty( $citation[ $field ] ) ) {
-								$parts[] = $info['prefix'] . '<a target="_blank" href="' . esc_url( $citation[ $field ] ) . '">' . esc_url( $citation[ $field ] ) . '</a>' . $info['suffix'];
-							} else {
+							case 'url':
 								$parts[] = $info['prefix'] . esc_url( $citation[ $field ] ) . $info['suffix'];
-							}
 							break;
 						default:
 							$parts[] = $info['prefix'] . esc_html( $citation[ $field ] ) . $info['suffix'];
@@ -239,7 +235,7 @@ class Citation {
 			'url'           => array(
 				'type'   => 'text',
 				'label'  => __( 'URL', 'candela-citation' ),
-				'prefix' => '<strong>' . __( 'Located at', 'candela-citation' ) . '</strong>: ',
+				'prefix' => '<strong>' . __( 'Retrieved from', 'candela-citation' ) . '</strong>: ',
 				'suffix' => '',
 			),
 			'project'       => array(


### PR DESCRIPTION
We've had an issue with some of the OER websites we have curated resources from in the past disappearing. This had led to a situation where the links back to those sources in the Attributions at the bottom of our course pages are "dead links." This creates problems with automated link checkers that accessibility services review perform on our courses. 

After some discussion, the learning team suggested the best way to solve this problem was to list the URLs where the resources were originally accessed, but not have them be live links (i.e., make them text-only). This PR does that. 

The PR also changes the relevant language within the attribution from "Located at:" to "Retrieved from:".

The PR was tested within the Docker-based PBJ environment.