### PR TITLE
Correcting Public Domain and CC0 links in attributions

### DIFF
--- a/inc/class-citation.php
+++ b/inc/class-citation.php
@@ -354,11 +354,11 @@ class Citation {
 				$options = array(
 					'pd'          => array(
 						'label' => __( 'Public Domain: No Known Copyright', 'candela-citation' ),
-						'link'  => 'https://creativecommons.org/about/pdm',
+						'link'  => 'https://creativecommons.org/publicdomain/mark/1.0/',
 					),
 					'cc0'         => array(
 						'label' => __( 'CC0: No Rights Reserved', 'candela-citation' ),
-						'link'  => 'https://creativecommons.org/about/cc0',
+						'link'  => 'https://creativecommons.org/publicdomain/zero/1.0/',
 					),
 					'cc-by'       => array(
 						'label' => __( 'CC BY: Attribution', 'candela-citation' ),


### PR DESCRIPTION
CC suggested back in 2015(!) that we fix these links so they point to the actual license pages instead of the licenses' "About" pages. Closed a five year old PR on the old candela repo (https://github.com/lumenlearning/candela/pull/105/commits/580e8d8c30d49275ad918136cb84fd6696183949) and created this new PR here where it belongs.